### PR TITLE
Enhance CSSStyleObserver API with Callback Mode as Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ cssStyleObserver.detach();               /* Detach observer */
 
 ### Callback Modes
 
-The CSSStyleObserver supports different modes for invoking the callback, specified via the callbackMode option in the options object:
+The `CSSStyleObserver` supports different modes for invoking the callback, specified via the `callbackMode` option in the `options` object:
 
-* CallbackMode.INDIVIDUAL: Only the changed property is passed to the callback function
-* CallbackMode.ALL: All observed properties are passed to the callback function, regardless of whether they changed or not
+* `CallbackMode.INDIVIDUAL`: Only the changed property is passed to the callback function
+* `CallbackMode.ALL`: All observed properties are passed to the callback function, regardless of whether they changed or not
 
+The default mode used is `CallbackMode.INDIVIDUAL`
 Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ cssStyleObserver.attach(document.body);  /* Attach observer to `document.body` *
 cssStyleObserver.detach();               /* Detach observer */
 ```
 
+Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)
+
 ### Callback Modes
 
 The `CSSStyleObserver` supports different modes for invoking the callback, specified via the `callbackMode` option in the `options` object:
@@ -61,7 +63,6 @@ The `CSSStyleObserver` supports different modes for invoking the callback, speci
 * `CallbackMode.ALL`: All observed properties are passed to the callback function, regardless of whether they changed or not
 
 The default mode used is `CallbackMode.INDIVIDUAL`
-Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ npm install @bramus/style-observer
 const CSSStyleObserver = require('@bramus/style-observer');
 
 // Vanilla JS (ES6)
-import CSSStyleObserver from '@bramus/style-observer';
+import CSSStyleObserver, { CallbackMode } from '@bramus/style-observer';
 
 // TypeScript
-import CSSStyleObserver from '@bramus/style-observer/src/index.ts'
+import CSSStyleObserver, { CallbackMode } from '@bramus/style-observer/src/index.ts'
 
 const cssStyleObserver = new CSSStyleObserver(
     /* CSS Properties to observe */
@@ -40,7 +40,10 @@ const cssStyleObserver = new CSSStyleObserver(
     /* This is called whenever there are changes */
     (values) => {
         console.log(values['--variable1'], values['--variable2'], values['display']);
-    }                               
+    },                               
+
+    /* options */
+    { callbackMode: CallbackMode.INDIVIDUAL } // Set the callback mode to 'individual' or 'all'
 );
 
 cssStyleObserver.attach(document.body);  /* Attach observer to `document.body` */
@@ -49,6 +52,13 @@ cssStyleObserver.attach(document.body);  /* Attach observer to `document.body` *
 
 cssStyleObserver.detach();               /* Detach observer */
 ```
+
+### Callback Modes
+
+The CSSStyleObserver supports different modes for invoking the callback, specified via the callbackMode option in the options object:
+
+* CallbackMode.INDIVIDUAL: Only the changed property is passed to the callback function
+* CallbackMode.ALL: All observed properties are passed to the callback function, regardless of whether they changed or not
 
 Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,9 +177,9 @@ export class CSSStyleObserver {
 
       // Do not invoke callback if no variables are defined
       if (Object.keys(variables).length > 0) {
-      this._callback(variables);
+        this._callback(variables);
+      }
     }
-  }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ export class CSSStyleObserver {
       const handler = this.modeHandlers[this._callbackMode] ?? this.modeHandlers[CallbackMode.INDIVIDUAL];
       handler(computedStyle, variables, propertyName);
 
-      // Invoke the callback if there are any variables
+      // Do not invoke callback if no variables are defined
       if (Object.keys(variables).length > 0) {
       this._callback(variables);
     }


### PR DESCRIPTION
This PR addresses and implements the feature discussed in #1 by enhancing the handling of callback modes in `CSSStyleObserver`. A configuration object `options` has been introduced and `callbackMode` is now included as part of this options object, making the API more flexible and scalable

The implementation now supports two distinct callback modes:

* `CallbackMode.INDIVIDUAL`: Only the changed property is passed to the callback function (default mode)
* `CallbackMode.ALL`: All observed properties are passed to the callback function, regardless of whether they changed or not

The mode handling is implemented using a strategy pattern, with each mode’s behavior encapsulated in its own handler function

The README has been updated to reflect these changes, providing usage instructions and descriptions for both callback modes and the default behavior