### PR TITLE
Introduce ReturnFormat option to allow detailed or value-only outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ cssStyleObserver.detach();               /* Detach observer */
     ```js
     {
         "--my-variable":{
-            "propertyName": "--my-variable",
             "value": "1.0",
             "previousValue": "0.0",
             "changed": true

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ npm install @bramus/style-observer
 const CSSStyleObserver = require('@bramus/style-observer');
 
 // Vanilla JS (ES6)
-import CSSStyleObserver, { NotificationMode } from '@bramus/style-observer';
+import CSSStyleObserver, { NotificationMode, ReturnFormat } from '@bramus/style-observer';
 
 // TypeScript
-import CSSStyleObserver, { NotificationMode } from '@bramus/style-observer/src/index.ts'
+import CSSStyleObserver, { NotificationMode, ReturnFormat } from '@bramus/style-observer/src/index.ts'
 
 const cssStyleObserver = new CSSStyleObserver(
     /* CSS Properties to observe */
@@ -43,7 +43,8 @@ const cssStyleObserver = new CSSStyleObserver(
     },                                                 
     /* Configuration options */
     {
-      notificationMode?: NotificationMode.CHANGED_ONLY
+      notificationMode?: NotificationMode.CHANGED_ONLY,
+      returnFormat?: ReturnFormat.VALUE_ONLY,
     }
 );
 
@@ -57,6 +58,25 @@ cssStyleObserver.detach();               /* Detach observer */
 ### Configuration options
 
 * `notificationMode` (`NotificationMode`, default: `CHANGED_ONLY`): Determines whether to pass all properties (`ALL`) or only the changed ones (`CHANGED_ONLY`) into the callback
+* `ReturnFormat` (`ReturnFormat`, default: `VALUE_ONLY`): Determines the format of the data passed to the callback. Below are the options:
+  * `VALUE_ONLY`: The callback receives an object with property names as keys and their current values:
+    ```js
+    {
+        "--my-variable": "1.0",
+        "display": "block"
+    }
+    ```
+  * `OBJECT`: The callback receives an array of objects containing detailed information about each property:
+    ```js
+    [
+        {
+            "propertyName": "--my-variable",
+            "value": "1.0",
+            "previousValue": "0.0",
+            "changed": true
+        }
+    ]
+    ```
 
 Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)
 

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ cssStyleObserver.detach();               /* Detach observer */
         "display": "block"
     }
     ```
-  * `OBJECT`: The callback receives an array of objects containing detailed information about each property:
+  * `OBJECT`: The callback receives an object with property names as keys and detailed information as values:
     ```js
-    [
-        {
+    {
+        "--my-variable":{
             "propertyName": "--my-variable",
             "value": "1.0",
             "previousValue": "0.0",
             "changed": true
         }
-    ]
+    }
     ```
 
 Try out a demo on CodePen: [https://codepen.io/bramus/pen/WNqKqxj](https://codepen.io/bramus/pen/WNqKqxj?editors=1111)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,6 @@ export type CSSDeclarations = { [key: string]: string };
  * ```
  */
 export interface CSSPropertyInfo {
-  propertyName: string;
   value: string;
   previousValue: string;
   changed: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ export type CSSDeclarations = { [key: string]: string };
  *     "changed": true
  *   },
  *   "display": {
- *     "propertyName": "display",
  *     "value": "flex",
  *     "previousValue": "flex",
  *     "changed": false

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,12 +244,12 @@ export class CSSStyleObserver {
     if (this._targetElement) {
       const computedStyle = getComputedStyle(this._targetElement);
 
-      // Execute the handler for the current return format, default to ReturnFormat.VALUE_ONLY if not valid
-      const handler = this._returnFormatHandlers[this._returnFormat] ?? this._returnFormatHandlers[ReturnFormat.VALUE_ONLY];
-      const changes = handler(computedStyle);
+      const changes = this. _processObservedVariables(computedStyle);
+      if (Object.keys(changes).length == 0) return;
       
-      if (Object.keys(changes).length > 0) {
-        this._callback(changes);
+      const format = this._returnFormatHandlers[this._returnFormat] ?? this._returnFormatHandlers[ReturnFormat.VALUE_ONLY];
+      const formattedChanges = format(changes);
+      this._callback(formattedChanges);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,20 +14,20 @@ export type CSSDeclarations = { [key: string]: string };
  * Structure holding detailed CSS property information
  *
  * ```json
- * [
- *   {
+ * {
+ *   "--my-variable": {
  *     "propertyName": "--my-variable",
  *     "value": "1.0",
  *     "previousValue": "0.5",
  *     "changed": true
  *   },
- *   {
+ *   "display": {
  *     "propertyName": "display",
  *     "value": "flex",
  *     "previousValue": "flex",
  *     "changed": false
  *   }
- * ]
+ * }
  * ```
  */
 export interface CSSPropertyInfo {
@@ -43,7 +43,7 @@ export interface CSSPropertyInfo {
  * @param values Readonly structure containing observed CSS properties and their values
  */
 export type CSSStyleObserverCallback = (
-  values: Readonly<CSSDeclarations | CSSPropertyInfo[]>
+  values: Readonly<CSSDeclarations | { [key: string]: CSSPropertyInfo }>
 ) => void;
 
 /**
@@ -231,17 +231,17 @@ export class CSSStyleObserver {
       });
     },
     [ReturnFormat.OBJECT]: (computedStyle) => {
-      const changes: CSSPropertyInfo[] = [];
+      const changes: { [key: string]: CSSPropertyInfo } = {};
 
       this._processChanges(computedStyle, (propertyName, currentValue, previousValue, hasChanged) => {
-        changes.push({
+        changes[propertyName] = {
           propertyName,
           value: currentValue,
           previousValue,
           changed: hasChanged,
-        });
+        };
       }, () => {
-        if (changes.length > 0) {
+        if (Object.keys(changes).length > 0) {
           this._callback(changes);
         }
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ export type CSSDeclarations = { [key: string]: string };
  * ```json
  * {
  *   "--my-variable": {
- *     "propertyName": "--my-variable",
  *     "value": "1.0",
  *     "previousValue": "0.5",
  *     "changed": true

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,6 @@ export class CSSStyleObserver {
 
       this._processChanges(computedStyle, (propertyName, currentValue, previousValue, hasChanged) => {
         changes[propertyName] = {
-          propertyName,
           value: currentValue,
           previousValue,
           changed: hasChanged,


### PR DESCRIPTION
This Pull Request addresses https://github.com/bramus/style-observer/issues/8 by introducing a new `ReturnFormat` option to the CSSStyleObserver. This enhancement allows users to choose between receiving only the current values of observed CSS properties or detailed information that includes previous values and change statuses

Changes

* Introduced the `ReturnFormat` enum with options `VALUE_ONLY` (default) and `OBJECT`
* Updated the `CSSStyleObserver` class to process observed properties based on the selected `ReturnFormat`
* Updated the `README.md` to reflect the new `ReturnFormat` option and provide usage examples